### PR TITLE
fix: load the storybook plugin lazily so disabling it needs no storybook

### DIFF
--- a/src/eslintStorybook.ts
+++ b/src/eslintStorybook.ts
@@ -20,12 +20,21 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
-import storybook from "eslint-plugin-storybook";
+import { Linter } from "eslint";
+import { createRequire } from "node:module";
+
+const requirePlugin = createRequire(import.meta.url);
 
 /**
- * ESLint Rule for Storybook
+ * ESLint config for Storybook, loaded lazily.
+ *
+ * @remarks eslint-plugin-storybook imports the `storybook` package at module
+ * load time. Requiring the plugin lazily -- only when this extend is enabled --
+ * means consumers that disable it (e.g. a Node library passing
+ * `disableExtends: ["eslintStorybook"]`) never need `storybook` installed.
  * @since 1.0.0
  */
-export const eslintStorybook = storybook.configs;
-
-export default eslintStorybook;
+export default function eslintStorybook(): Linter.Config[] {
+  const storybook = requirePlugin("eslint-plugin-storybook");
+  return storybook.configs["flat/recommended"];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,16 +53,25 @@ export const globalIgnoresArray = [
  * @remarks These are items that can be disabled.
  * @since 1.0.0
  */
+/**
+ * A lazy producer of one extend's config. Loading is deferred so a disabled
+ * extend never loads its plugin -- critical for eslintStorybook, whose plugin
+ * imports the `storybook` package at load time. The explicit return type keeps
+ * the inferred map type portable for declaration emit.
+ * @since 1.0.0
+ */
+type ExtendFactory = () => Linter.Config | Linter.Config[];
+
 const baseExtendsMap = {
-  eslintA11y: eslintA11y.recommended as Linter.Config,
-  eslintPerfectionist: eslintPerfectionist as Linter.Config,
-  eslintPrettier: eslintPrettier as Linter.Config,
-  eslintReact: eslintReact as Linter.Config,
-  eslintStorybook: eslintStorybook["flat/recommended"] as Linter.Config[],
-  eslintTesting: eslintTesting as Linter.Config,
-  eslintTypescript: eslintTypescript.recommended as Linter.Config[],
-  eslintUnicorn: eslintUnicorn as Linter.Config,
-} as const;
+  eslintA11y: (() => eslintA11y.recommended) as ExtendFactory,
+  eslintPerfectionist: (() => eslintPerfectionist) as ExtendFactory,
+  eslintPrettier: (() => eslintPrettier) as ExtendFactory,
+  eslintReact: (() => eslintReact) as ExtendFactory,
+  eslintStorybook: (() => eslintStorybook()) as ExtendFactory,
+  eslintTesting: (() => eslintTesting) as ExtendFactory,
+  eslintTypescript: (() => eslintTypescript.recommended) as ExtendFactory,
+  eslintUnicorn: (() => eslintUnicorn) as ExtendFactory,
+};
 
 /**
  * Default rules applied on top of the bundled extends.
@@ -104,7 +113,7 @@ export function createESLintConfig(options?: {
         .filter(
           ([key]) => !disabled.includes(key as keyof typeof baseExtendsMap),
         )
-        .map(([, value]) => value as Linter.Config),
+        .map(([, factory]) => factory()),
       rules: {
         ...baseRules,
         ...userRules,


### PR DESCRIPTION
eslint-plugin-storybook imports the `storybook` package at module load, so importing this config pulled `storybook` in even when `eslintStorybook` was disabled. Node libraries that disable the extend (e.g. a Fastify plugin) crashed at ESLint config load with `ERR_MODULE_NOT_FOUND: Cannot find package 'storybook'`, because their clean installs do not have `storybook`.

## What
- Each entry in `baseExtendsMap` is now a lazy factory; `eslintStorybook` requires `eslint-plugin-storybook` only when the extend is enabled.
- The other extends are unchanged in behaviour.
- An `ExtendFactory` type keeps declaration emit portable (fixes the TS2883 the naive change triggered).

## Verification
- `npm run build` and `npm test` pass (19 passed, 1 skipped).
- Compiled output no longer requires `eslint-plugin-storybook` at the top level; it is loaded only inside the lazy factory, invoked only for enabled extends.

## Acceptance
- A consumer with no `storybook` installed and `disableExtends: ["eslintStorybook"]` lints without crashing.