### PR TITLE
fix: skip Storybook config when storybook is not installed

### DIFF
--- a/src/eslintStorybook.ts
+++ b/src/eslintStorybook.ts
@@ -26,15 +26,21 @@ import { createRequire } from "node:module";
 const requirePlugin = createRequire(import.meta.url);
 
 /**
- * ESLint config for Storybook, loaded lazily.
+ * ESLint config for Storybook, loaded lazily and treated as optional.
  *
  * @remarks eslint-plugin-storybook imports the `storybook` package at module
- * load time. Requiring the plugin lazily -- only when this extend is enabled --
- * means consumers that disable it (e.g. a Node library passing
- * `disableExtends: ["eslintStorybook"]`) never need `storybook` installed.
+ * load time. The plugin is required lazily (only when this extend is resolved)
+ * AND guarded: the default export resolves every extend at module load, so a
+ * project without `storybook` would otherwise crash on `import` even when it
+ * disables this extend. When `storybook` is absent the Storybook config is
+ * skipped instead, so Node libraries never need to install it.
  * @since 1.0.0
  */
 export default function eslintStorybook(): Linter.Config[] {
-  const storybook = requirePlugin("eslint-plugin-storybook");
-  return storybook.configs["flat/recommended"];
+  try {
+    const storybook = requirePlugin("eslint-plugin-storybook");
+    return storybook.configs["flat/recommended"];
+  } catch {
+    return [];
+  }
 }


### PR DESCRIPTION
Follow-up to #27. The default export (`createESLintConfig()` with no options) is evaluated at module load and resolves **every** extend, so simply importing the package ran the Storybook factory — pulling in `eslint-plugin-storybook`, which imports the `storybook` package. Any consumer without `storybook` therefore crashed at `import` with `ERR_MODULE_NOT_FOUND`, even when it passed `disableExtends: ["eslintStorybook"]`.

## What
- The Storybook factory now wraps its lazy `require` in a try/catch: if `storybook` is not installed, it returns an empty config instead of throwing. Storybook is effectively optional.

## Verification
- `npm run build` + `npm test` pass.
- Built `lib/` overlaid into a Node library with no `storybook` installed and `disableExtends: ["eslintStorybook"]`: `eslint .` passes (previously `ERR_MODULE_NOT_FOUND`).
- Frontend projects with `storybook` installed still receive the Storybook config.