### PR TITLE
fix: use the org App client-id var for the release token

### DIFF
--- a/.github/workflows/job-version-bump.yaml
+++ b/.github/workflows/job-version-bump.yaml
@@ -40,7 +40,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3.2.0
         with:
-          client-id: "Iv23ligVrrLzGPXe28dn"
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: 📂 Checkout Code


### PR DESCRIPTION
## What and why

The Release Manager failed on the last push with `A JSON web token could not be decoded`. The governance adoption hardcoded the Bugs5382 App client-id, but this org repo authenticates with its own GitHub App via `vars.APP_CLIENT_ID` and the matching `APP_PRIVATE_KEY` secret. The mismatched pair broke token creation. Restore the org's own `vars.APP_CLIENT_ID`.

Refs #31