### PR TITLE
fix: npm publish fails on build-artifact name mismatch

### DIFF
--- a/.github/workflows/action-deploy-npm.yaml
+++ b/.github/workflows/action-deploy-npm.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v8
         with:
-          name: cache
+          name: lib
           path: ./
 
       - name: Setup Node.js
@@ -63,4 +63,3 @@ jobs:
           access: public
           ignore-scripts: true
           token: ${{ secrets.NPM_TOKEN }}
-          tag: ${{ steps.set-npm-tag.outputs.NPM_TAG }}


### PR DESCRIPTION
## What and why

The `Release and Publish` workflow failed at *Download the build artifact* (`Artifact not found for name: cache`) — `action-test` uploads the build as `lib`, but Publish downloaded `cache`, so v0.4.1 never published. The `tag:` input also referenced a non-existent `set-npm-tag` step (empty value).

## Changes

- Download the artifact as `lib` (matching the upload).
- Remove the dangling `tag:` reference so npm-publish uses its default dist-tag.

## Verification

- Re-running `Release and Publish` (workflow_dispatch) downloads `lib` and publishes.

Closes #35