### PR TITLE
chore(release): collapse v0.4.2 into v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @the-rabbit-hole/eslint-config
 
+## v0.4.2 - 2026-06-13
+
+### What Changed 👀
+
+#### 🐛 Bug Fixes
+
+- fix: npm publish fails on build-artifact name mismatch @Bugs5382 (#36)
+
+### Extra
+
+**Full Changelog**: https://github.com/the-rabbit-hole-tech/eslint-config/compare/v0.4.1...v0.4.2
+
 ## v0.4.1 - 2026-06-13
 
 ### What Changed 👀

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,6 +1,6 @@
 version: '3'
 vars:
-  VERSION: "v0.4.1"
+  VERSION: "v0.4.2"
   GOLIC_VERSION: v0.2.0
   COMMON_LIC: "2026 Shane"
   TEMPLATE_LIC: "mit"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-rabbit-hole/eslint-config",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A eslint config designed for @the-rabbit-hole projects, but can be used publicly.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## What and why

v0.4.1 was never tagged or published (its draft release was cleaned up), so the two bug fixes since v0.4.0 — #34 (release App client-id) and #36 (publish artifact name) — should ship together as a single **v0.4.1**, not split into v0.4.1 + v0.4.2. The pre-release automation had advanced the manifest/changelog to 0.4.2.

## Changes

- Merge the changelog `v0.4.2` and `v0.4.1` entries into one `v0.4.1` (both fixes).
- Set `package.json` version back to `0.4.1`.

The release draft is retagged to v0.4.1 separately. This is a `chore`/skip-changelog change, so the Release Manager's releasable gate won't re-bump on merge.

Refs #35