### PR TITLE
chore(release): collapse v0.4.2 into v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,12 @@
 # @the-rabbit-hole/eslint-config
 
-## v0.4.2 - 2026-06-13
-
-### What Changed 👀
-
-#### 🐛 Bug Fixes
-
-- fix: npm publish fails on build-artifact name mismatch @Bugs5382 (#36)
-
-### Extra
-
-**Full Changelog**: https://github.com/the-rabbit-hole-tech/eslint-config/compare/v0.4.1...v0.4.2
-
 ## v0.4.1 - 2026-06-13
 
 ### What Changed 👀
 
 #### 🐛 Bug Fixes
 
+- fix: npm publish fails on build-artifact name mismatch @Bugs5382 (#36)
 - fix: use the org App client-id var for the release token @Bugs5382 (#34)
 
 ### Extra

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,6 +1,6 @@
 version: '3'
 vars:
-  VERSION: "v0.4.2"
+  VERSION: "v0.4.1"
   GOLIC_VERSION: v0.2.0
   COMMON_LIC: "2026 Shane"
   TEMPLATE_LIC: "mit"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-rabbit-hole/eslint-config",
-  "version": "0.4.2",
+  "version": "0.4.1",
   "description": "A eslint config designed for @the-rabbit-hole projects, but can be used publicly.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## What and why

v0.4.1 was never tagged or published (its draft release was cleaned up), so the two bug fixes since v0.4.0 — #34 (release App client-id) and #36 (publish artifact name) — belong in a single **v0.4.1**, not split into v0.4.1 + v0.4.2. The pre-release automation had advanced the manifest/Taskfile/changelog to 0.4.2.

## Changes

- `package.json` and `Taskfile.yaml` version back to `0.4.1`.
- Merge the changelog `v0.4.2` + `v0.4.1` entries into one `v0.4.1` (both fixes).

The draft release is retagged v0.4.2 → v0.4.1 separately. `chore`/skip-changelog, so the releasable gate won't re-bump on merge.

Refs #35