### PR TITLE
feat: add opt-in eslintTypedoc extend, pin Prettier, and upgrade deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,36 +5,57 @@ hook-enforced rules). Keep this file current when the build, layout, or public A
 
 ## What this is
 
-A common ESLINT config used in my projects.
-
-<!-- Fill in: what the project does, what it ships (library, service, action, CLI), and the one or
-two things an agent must understand before changing it. -->
+`@the-rabbit-hole/eslint-config` is the shared, flat-config ESLint preset used across the
+`@the-rabbit-hole` projects (and usable publicly). It ships a single factory, `createESLintConfig`,
+that composes a curated set of plugin configs (TypeScript, React, jsx-a11y, unicorn, perfectionist,
+prettier, testing-library, storybook) and lets a consumer disable bundled extends, enable opt-in
+extends, and merge/override rules. It is published to npm as dual ESM/CJS with type declarations.
 
 ## Using eslint-config
 
-<!-- If this project is consumed by others (a library/plugin/action), describe the contract a
-consumer must respect: the single entry point, the public surface, required options, and anything
-that must not be bypassed. Delete this section for a leaf application. -->
+The public surface is the entry point `@the-rabbit-hole/eslint-config`:
+
+- `default` export — the ready-made config (all base extends on).
+- `createESLintConfig(options?)` — the factory. Options:
+  - `disableExtends` — keys of base (default-on) extends to remove.
+  - `enable` — keys of opt-in (default-off) extends to add; currently `eslintTypedoc`.
+  - `rules` — rules merged on top of the bundled defaults; a key that collides with a bundled
+    default replaces it and logs an info line.
+- `globalIgnoresArray` — the shared ignore patterns.
+
+Contract: extends load **lazily** so a disabled extend never imports its plugin. This matters for
+`eslintStorybook`, whose plugin imports the `storybook` package at load time — the Storybook extend
+is both lazy and guarded so Node libraries that don't install `storybook` never crash. Preserve that
+laziness when adding extends whose plugins have heavy or optional load-time imports.
 
 ## Layout
 
-<!-- The directories that matter and what lives in each. Keep it short; point at the entry points. -->
-
-- `src/` - <what>
-- `<tests dir>/` - <what>
+- `src/index.ts` — the factory, the base/opt-in extend maps, default rules, and the default export.
+- `src/eslint*.ts` — one file per bundled plugin config (e.g. `eslintTypescript.ts`,
+  `eslintUnicorn.ts`, `eslintTypedoc.ts`). Each is a thin wrapper around an upstream preset.
+- `__tests__/index.test.ts` — unit tests for option wiring (shape of the produced config).
+- `__tests__/integration.test.ts` — real `ESLint` runs that assert specific plugin rules fire (or
+  don't) for sample code. Note the documented `eslint-plugin-react` + ESLint v10 incompatibility,
+  which keeps the React rule explicitly skipped until upstream ships a fix.
 
 ## Build, test, lint
 
-<!-- The exact commands. Pull these from package.json scripts (npm), the Taskfile (Go/Task), or
-pyproject (Python) so they stay accurate. -->
-
-- Build: `<command>`
-- Test: `<command>` (note any service/fixture the integration tests require)
-- Lint: `<command>`
-- License headers / docs: `<command>`
+- Build: `npm run build` (tsdown → `lib/` ESM+CJS+d.ts).
+- Test: `npm test` (vitest). Integration tests run real ESLint; no external services.
+- Lint: `npm run lint` (`eslint | snazzy`); `npm run lint:fix` to autofix.
+- Package hygiene: `npm run lint:npm` (npmPkgJsonLint) and `npx sort-package-json`.
+- License headers: `task golic-run -- ...` (golic verifies the MIT header on every source file in
+  CI; the copyright holder is configured as `2026 Shane` in `Taskfile.yaml`).
 
 ## Conventions and gotchas
 
 - See `CLAUDE.md` for the branch/commit/PR rules; they are enforced by the git hooks in
   `.claude/hooks` (run `bash .claude/hooks/install.sh` once per clone).
-- <project-specific conventions, non-obvious constraints, and traps an agent should know>
+- This package **dogfoods its own built config** via `eslint.config.mjs`, which imports from
+  `./lib/esm`. Run `npm run build` before `npm run lint` after changing `src/`.
+- `eslint-plugin-prettier` formats with whatever Prettier resolves, so Prettier is pinned as an
+  **exact direct dependency** (not a floating peer) to keep formatting deterministic. Bump it
+  deliberately — a Prettier change is a changelogged release.
+- Adding a plugin: create `src/eslint<Name>.ts`, register it in `baseExtendsMap` (default-on) or
+  `optInExtendsMap` (default-off) in `src/index.ts`, add unit + integration coverage, and document
+  it in `README.md`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![npm version](https://img.shields.io/npm/v/@the-rabbit-hole/eslint-config?style=for-the-badge&logo=npm&label=version)
 ![npm downloads](https://img.shields.io/npm/dm/@the-rabbit-hole/eslint-config?style=for-the-badge&logo=npm&label=downloads)
-![ESLint](https://img.shields.io/badge/ESLint-9.x-4B32C3?style=for-the-badge&logo=eslint&logoColor=white)
+![ESLint](https://img.shields.io/badge/ESLint-9.x%20%7C%2010.x-4B32C3?style=for-the-badge&logo=eslint&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
 ![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)
 
@@ -51,6 +51,9 @@ export default createESLintConfig({
   // Drop bundled extends you don't want
   disableExtends: ["eslintReact", "eslintA11y", "eslintStorybook"],
 
+  // Turn on opt-in extends that are off by default
+  enable: ["eslintTypedoc"],
+
   // Add your own rules — or override bundled ones
   rules: {
     "no-console": "error",                // additive — applied as-is
@@ -59,7 +62,7 @@ export default createESLintConfig({
 });
 ```
 
-Both options are independent — pass either, both, or neither.
+All options are independent — pass any combination, or none.
 
 #### Override notifications
 
@@ -75,6 +78,19 @@ Adding rules the package does not set is silent — no message.
 
 `eslintA11y` · `eslintPerfectionist` · `eslintPrettier` · `eslintReact` · `eslintStorybook` · `eslintTesting` · `eslintTypescript` · `eslintUnicorn`
 
+#### Opt-in extends (`enable`)
+
+These are **off by default** and only applied when named in `enable`:
+
+* `eslintTypedoc` — enforces [TypeDoc](https://typedoc.org)/TSDoc documentation quality via [eslint-plugin-typedoc](https://github.com/Nick2bad4u/eslint-plugin-typedoc): doc-comment coverage on exported APIs (`typedoc/require-exported-doc-comment`), plus tag correctness (unknown/duplicate/empty tags, malformed inline links). It is opt-in so non-library consumers aren't forced into doc-coverage errors. Scoped to `**/*.{ts,tsx,mts,cts}`.
+
+```js
+import { createESLintConfig } from "@the-rabbit-hole/eslint-config";
+
+// A library that wants its public API documentation linted:
+export default createESLintConfig({ enable: ["eslintTypedoc"] });
+```
+
 ## 🧩 What’s Included?
 
 This ESLint config comes pre-bundled with a set of plugins and shareable configs tailored for modern TypeScript + React projects:
@@ -88,6 +104,14 @@ This ESLint config comes pre-bundled with a set of plugins and shareable configs
 * [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) 🎨 — Run Prettier as an ESLint rule
 * [eslint-plugin-perfectionist](https://perfectionist.dev) 🪄 — Enforces sorting and consistency
 * [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn) 🦄— Massive rules for good code
+
+### Opt-in plugins
+
+* [eslint-plugin-typedoc](https://github.com/Nick2bad4u/eslint-plugin-typedoc) 📚 — TypeDoc/TSDoc documentation quality (enable with `enable: ["eslintTypedoc"]`)
+
+## 🎨 A note on Prettier
+
+`eslint-plugin-prettier` runs Prettier as an ESLint rule, so the **Prettier version decides the formatting**. To keep `prettier/prettier` verdicts deterministic, this package ships **Prettier as a pinned, exact dependency** rather than a floating peer — the formatter engine only changes in an intentional, changelogged release. You do **not** need to install or pin Prettier yourself; remove any `prettier` peer expectation you previously satisfied for this config.
 
 ## 🤝 Contributing
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -81,6 +81,28 @@ describe("createESLintConfig", () => {
     });
   });
 
+  describe("enable (opt-in extends)", () => {
+    it("does not include eslintTypedoc by default", () => {
+      const config = createESLintConfig() as ConfigEntry[];
+      expect(includesPlugin(config, "typedoc")).toBe(false);
+    });
+
+    it("adds eslintTypedoc only when named in enable", () => {
+      const config = createESLintConfig({
+        enable: ["eslintTypedoc"],
+      }) as ConfigEntry[];
+      expect(includesPlugin(config, "typedoc")).toBe(true);
+    });
+
+    it("leaves the base extends intact when an opt-in extend is enabled", () => {
+      const config = createESLintConfig({
+        enable: ["eslintTypedoc"],
+      }) as ConfigEntry[];
+      expect(includesPlugin(config, "unicorn")).toBe(true);
+      expect(includesPlugin(config, "typescript-eslint")).toBe(true);
+    });
+  });
+
   describe("rules", () => {
     it("applies the bundled default rule when no user rules are provided", () => {
       const config = createESLintConfig() as ConfigEntry[];

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -172,6 +172,37 @@ describe("integration: real ESLint run against sample code (default config minus
   );
 });
 
+describe("integration: eslintTypedoc opt-in extend", () => {
+  // An exported symbol with no doc comment trips
+  // `typedoc/require-exported-doc-comment` once the extend is enabled.
+  const UNDOCUMENTED_EXPORT = "export const value = 1;\n";
+
+  it(
+    "does not fire typedoc rules unless enabled",
+    async () => {
+      const eslint = newEslint({ disableExtends: ["eslintReact"] });
+      const messages = await lint(eslint, UNDOCUMENTED_EXPORT, "sample.ts");
+      expect(hasPluginRule(messages, "typedoc/")).toBe(false);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "fires typedoc/require-exported-doc-comment when enabled",
+    async () => {
+      const eslint = newEslint({
+        disableExtends: ["eslintReact"],
+        enable: ["eslintTypedoc"],
+      });
+      const messages = await lint(eslint, UNDOCUMENTED_EXPORT, "sample.ts");
+      expect(ruleIds(messages)).toContain(
+        "typedoc/require-exported-doc-comment",
+      );
+    },
+    TEST_TIMEOUT,
+  );
+});
+
 describe("integration: option wiring with various plugins on / off", () => {
   it(
     "disableExtends actually drops the plugin's rules at lint time",

--- a/package.json
+++ b/package.json
@@ -56,40 +56,40 @@
   "dependencies": {
     "@eslint/js": "^10.0.1",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "eslint-plugin-perfectionist": "^5.9.0",
+    "eslint-plugin-perfectionist": "^5.9.1",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-sort-class-members": "^1.22.1",
-    "eslint-plugin-storybook": "^10.4.2",
+    "eslint-plugin-storybook": "^10.4.6",
     "eslint-plugin-testing-library": "^7.16.2",
-    "eslint-plugin-unicorn": "^65.0.1",
-    "typescript-eslint": "^8.61.0"
+    "eslint-plugin-typedoc": "^1.3.5",
+    "eslint-plugin-unicorn": "^69.0.0",
+    "prettier": "3.9.4",
+    "typescript-eslint": "^8.62.1"
   },
   "devDependencies": {
-    "@commitlint/cli": "^21.0.2",
-    "@commitlint/config-conventional": "^21.0.2",
+    "@commitlint/cli": "^21.2.0",
+    "@commitlint/config-conventional": "^21.2.0",
     "@shipgirl/typedoc-plugin-versions": "^0.3.2",
     "@types/eslint-plugin-jsx-a11y": "^6.10.1",
     "@types/eslint-plugin-tailwindcss": "^3.17.0",
-    "@types/node": "^25.9.3",
-    "@vitest/coverage-v8": "^4.1.8",
-    "eslint": "^10.5.0",
-    "globals": "^17.6.0",
-    "npm": "^11.17.0",
-    "npm-package-json-lint": "^10.4.0",
+    "@types/node": "^26.0.1",
+    "@vitest/coverage-v8": "^4.1.9",
+    "eslint": "^10.6.0",
+    "globals": "^17.7.0",
+    "npm": "^11.18.0",
+    "npm-package-json-lint": "^10.4.1",
     "npm-package-json-lint-config-default": "^9.0.1",
-    "prettier": "3.8.4",
     "snazzy": "^9.0.0",
     "sort-package-json": "^4.0.0",
-    "storybook": "^10.4.4",
-    "tsdown": "^0.22.2",
+    "storybook": "^10.4.6",
+    "tsdown": "^0.22.3",
     "typedoc": "^0.28.19",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.9"
   },
   "peerDependencies": {
-    "eslint": "^9.39.4 || ^10.0.0",
-    "prettier": "^3.8.3"
+    "eslint": "^9.39.4 || ^10.0.0"
   },
-  "packageManager": "npm@11.13.0"
+  "packageManager": "npm@11.18.0"
 }

--- a/src/eslintTypedoc.ts
+++ b/src/eslintTypedoc.ts
@@ -21,32 +21,19 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 import { Linter } from "eslint";
-import eslintPluginUnicorn from "eslint-plugin-unicorn";
+import typedocPlugin from "eslint-plugin-typedoc";
 
 /**
- * ESLint for Unicorn
+ * ESLint for TypeDoc / TSDoc documentation quality.
+ *
+ * @remarks Wraps `eslint-plugin-typedoc`'s `recommended` preset, which enforces
+ * doc-comment coverage on exported APIs (`require-exported-doc-comment`) and
+ * tag correctness (unknown/duplicate/empty tags, malformed inline links). The
+ * preset is already scoped to `**\/*.{ts,tsx,mts,cts}`. This extend is opt-in
+ * so non-library consumers are not forced into doc-coverage errors -- enable it
+ * via `createESLintConfig({ enable: ["eslintTypedoc"] })`.
+ * @since 0.5.0
  */
-export const eslintUnicorn: Linter.Config = {
-  ...eslintPluginUnicorn.configs.recommended,
-  rules: {
-    ...eslintPluginUnicorn.configs.recommended.rules,
-    // unicorn v69 added `consistent-boolean-name` to `recommended` at the
-    // error level, forcing every boolean to start with is/has/should/etc.
-    // That would turn existing, well-named booleans across consumer projects
-    // into hard errors on a routine upgrade, so it is disabled here and left
-    // as a deliberate opt-in rather than shipped silently.
-    "unicorn/consistent-boolean-name": "off",
-    "unicorn/filename-case": [
-      "warn",
-      {
-        case: "camelCase",
-        // Permit the `__dunder__` directory convention (`__tests__`,
-        // `__mocks__`, `__snapshots__`) that unicorn v69 began flagging when
-        // it started checking directory segments.
-        ignore: [/^__\w+__$/u],
-      },
-    ],
-  },
-};
+export const eslintTypedoc = typedocPlugin.configs.recommended as Linter.Config;
 
-export default eslintUnicorn;
+export default eslintTypedoc;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import eslintPrettier from "./eslintPretter";
 import eslintReact from "./eslintReact";
 import eslintStorybook from "./eslintStorybook";
 import eslintTesting from "./eslintTesting";
+import eslintTypedoc from "./eslintTypedoc";
 import eslintTypescript from "./eslintTypescript";
 import eslintUnicorn from "./eslintUnicorn";
 
@@ -74,6 +75,18 @@ const baseExtendsMap = {
 };
 
 /**
+ * Opt-in extends with string keys.
+ * @remarks Unlike {@link baseExtendsMap}, these are never applied unless named
+ * in `createESLintConfig({ enable })`. `eslintTypedoc` enforces TSDoc/TypeDoc
+ * doc-comment coverage on exported APIs, so it is opt-in to keep non-library
+ * consumers from being forced into doc-coverage errors.
+ * @since 0.5.0
+ */
+const optInExtendsMap = {
+  eslintTypedoc: (() => eslintTypedoc) as ExtendFactory,
+};
+
+/**
  * Default rules applied on top of the bundled extends.
  * @since 1.0.0
  */
@@ -85,15 +98,19 @@ const baseRules: Linter.RulesRecord = {
  * Factory to create ESLint config
  * @since 1.0.0
  * @param options.disableExtends - Extend names (keys) to remove from base config
+ * @param options.enable - Opt-in extend names (keys) to add on top of the base
+ *   config. Currently `eslintTypedoc` (TSDoc/TypeDoc doc-coverage enforcement).
  * @param options.rules - Rules to merge on top of the base rules. Keys that
  *   collide with a base rule will replace it; an info message is printed for
  *   each override so the consumer is aware.
  */
 export function createESLintConfig(options?: {
   disableExtends?: (keyof typeof baseExtendsMap)[];
+  enable?: (keyof typeof optInExtendsMap)[];
   rules?: Linter.RulesRecord;
 }) {
   const disabled = options?.disableExtends ?? [];
+  const enabled = options?.enable ?? [];
   const userRules = options?.rules ?? {};
 
   for (const ruleName of Object.keys(userRules)) {
@@ -109,11 +126,18 @@ export function createESLintConfig(options?: {
       ignores: globalIgnoresArray,
     },
     {
-      extends: Object.entries(baseExtendsMap)
-        .filter(
-          ([key]) => !disabled.includes(key as keyof typeof baseExtendsMap),
-        )
-        .map(([, factory]) => factory()),
+      extends: [
+        ...Object.entries(baseExtendsMap)
+          .filter(
+            ([key]) => !disabled.includes(key as keyof typeof baseExtendsMap),
+          )
+          .map(([, factory]) => factory()),
+        ...Object.entries(optInExtendsMap)
+          .filter(([key]) =>
+            enabled.includes(key as keyof typeof optInExtendsMap),
+          )
+          .map(([, factory]) => factory()),
+      ],
       rules: {
         ...baseRules,
         ...userRules,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": false,
-    "baseUrl": "."
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## What and why

A combined release that lands the opt-in TypeDoc lint profile, removes a formatting-determinism footgun, and brings every dependency to latest.

### Opt-in `eslintTypedoc` extend (closes #44)

Adds [`eslint-plugin-typedoc`](https://github.com/Nick2bad4u/eslint-plugin-typedoc) as a new **opt-in** extend, exposed via a new `enable` option:

```js
createESLintConfig({ enable: ["eslintTypedoc"] });
```

It wraps the plugin's `recommended` preset — doc-comment coverage on exported APIs (`typedoc/require-exported-doc-comment`) plus tag correctness (unknown/duplicate/empty tags, malformed inline links), scoped to `**/*.{ts,tsx,mts,cts}`. It stays **off by default** so non-library consumers aren't forced into doc-coverage errors, exactly as the issue asked.

### Pin Prettier as an exact dependency (closes #46)

`eslint-plugin-prettier` formats with whatever Prettier resolves, so the floating peer (`^3.8.3`) made `prettier/prettier` verdicts drift across 3.x minors (3.9.0 changed type-union wrapping → pass locally, fail in CI). Prettier is now a **pinned, exact direct dependency** (`3.9.4`) and removed from `peerDependencies`; the formatter engine only changes in an intentional, changelogged release.

### Upgrade all dependencies to latest

eslint 10.6, typescript-eslint 8.62, eslint-plugin-unicorn 69, vitest 4.1.9, commitlint 21.2, and the rest.

- **unicorn 69** promotes `consistent-boolean-name` to an error in `recommended`. Shipping that would turn existing, well-named booleans across consumer projects into hard errors on a routine upgrade, so it is **disabled** here (left as a deliberate opt-in). The `__dunder__` directory convention (`__tests__`, `__mocks__`) is allowed through `filename-case`.
- **eslint-plugin-react** has no eslint-v10-compatible release yet (latest 7.37.5 peers `eslint ^9.7`, and `react/display-name` calls the removed `context.getFilename()`), so it stays pinned and explicitly skipped in the integration suite until upstream ships a fix.

### Also

Restores the `npm run docs` (typedoc) build, which was already broken on `main` — drops the TS6-deprecated `baseUrl` and loads node types in the tsconfig. README and AGENTS.md updated for the new option, plugin, and Prettier policy.

Closes #44
Closes #46

## Verification

- [x] Lint clean (`npm run lint`)
- [x] Tests pass (`npm test` — 24 passed, 1 skipped: the documented react/v10 case)
- [x] Build succeeds (`npm run build`)
- [x] Documentation updated (README, AGENTS.md)

## How this was verified

`npm run build`, `npm test`, `npm run lint`, `npm run lint:npm`, and `sort-package-json --check` all green on the final tree. New unit tests assert `enable: ["eslintTypedoc"]` adds the typedoc plugin (and that it is absent by default); new integration tests run real ESLint and confirm `typedoc/require-exported-doc-comment` fires only when enabled. Confirmed `npm run docs` now generates HTML (it failed on `main`).