### PR TITLE
feat: make jsx-a11y, testing-library, and storybook opt-in extends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,15 @@ hook-enforced rules). Keep this file current when the build, layout, or public A
 
 `@the-rabbit-hole/eslint-config` is the shared, flat-config ESLint preset used across the
 `@the-rabbit-hole` projects (and usable publicly). It ships a single factory, `createESLintConfig`,
-that composes a curated set of plugin configs (TypeScript, React, jsx-a11y, unicorn, perfectionist,
-prettier, testing-library, storybook) and lets a consumer disable bundled extends, enable opt-in
-extends, and merge/override rules. It is published to npm as dual ESM/CJS with type declarations.
+that composes a curated set of plugin configs and lets a consumer disable default-on extends, enable
+opt-in extends, and merge/override rules. It is published to npm as dual ESM/CJS with type
+declarations.
+
+Extends split into two groups (see `baseExtendsMap` / `optInExtendsMap` in `src/index.ts`):
+
+- **Default-on** (every consumer): TypeScript, React, unicorn, perfectionist, prettier.
+- **Opt-in** (off unless named in `enable`): jsx-a11y, testing-library, storybook, typedoc — each
+  targets React/test/doc-specific code, so a plain Node library does not inherit them.
 
 ## Using eslint-config
 
@@ -18,7 +24,8 @@ The public surface is the entry point `@the-rabbit-hole/eslint-config`:
 - `default` export — the ready-made config (all base extends on).
 - `createESLintConfig(options?)` — the factory. Options:
   - `disableExtends` — keys of base (default-on) extends to remove.
-  - `enable` — keys of opt-in (default-off) extends to add; currently `eslintTypedoc`.
+  - `enable` — keys of opt-in (default-off) extends to add: `eslintA11y`, `eslintStorybook`,
+    `eslintTesting`, `eslintTypedoc`.
   - `rules` — rules merged on top of the bundled defaults; a key that collides with a bundled
     default replaces it and logs an info line.
 - `globalIgnoresArray` — the shared ignore patterns.

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Use the named `createESLintConfig` factory to disable bundled extends, add new r
 import { createESLintConfig } from "@the-rabbit-hole/eslint-config";
 
 export default createESLintConfig({
-  // Drop bundled extends you don't want
-  disableExtends: ["eslintReact", "eslintA11y", "eslintStorybook"],
+  // Drop default-on extends you don't want
+  disableExtends: ["eslintReact"],
 
   // Turn on opt-in extends that are off by default
-  enable: ["eslintTypedoc"],
+  enable: ["eslintA11y", "eslintTypedoc"],
 
   // Add your own rules — or override bundled ones
   rules: {
@@ -74,40 +74,48 @@ If a key in `rules` matches a rule the package sets by default, an info line is 
 
 Adding rules the package does not set is silent — no message.
 
-#### Available `disableExtends` keys
+#### Available `disableExtends` keys (default-on extends)
 
-`eslintA11y` · `eslintPerfectionist` · `eslintPrettier` · `eslintReact` · `eslintStorybook` · `eslintTesting` · `eslintTypescript` · `eslintUnicorn`
+`eslintPerfectionist` · `eslintPrettier` · `eslintReact` · `eslintTypescript` · `eslintUnicorn`
 
 #### Opt-in extends (`enable`)
 
-These are **off by default** and only applied when named in `enable`:
+These are **off by default** and only applied when named in `enable`. They target a specific kind of project rather than every consumer, so a plain Node library never inherits rules it has no use for:
 
-* `eslintTypedoc` — enforces [TypeDoc](https://typedoc.org)/TSDoc documentation quality via [eslint-plugin-typedoc](https://github.com/Nick2bad4u/eslint-plugin-typedoc): doc-comment coverage on exported APIs (`typedoc/require-exported-doc-comment`), plus tag correctness (unknown/duplicate/empty tags, malformed inline links). It is opt-in so non-library consumers aren't forced into doc-coverage errors. Scoped to `**/*.{ts,tsx,mts,cts}`.
+* `eslintA11y` — JSX accessibility rules ([eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)), for React component code.
+* `eslintStorybook` — Storybook story linting ([eslint-plugin-storybook](https://github.com/storybookjs/eslint-plugin-storybook)).
+* `eslintTesting` — Testing Library rules ([eslint-plugin-testing-library](https://github.com/testing-library/eslint-plugin-testing-library)), for test files.
+* `eslintTypedoc` — [TypeDoc](https://typedoc.org)/TSDoc documentation quality ([eslint-plugin-typedoc](https://github.com/Nick2bad4u/eslint-plugin-typedoc)): doc-comment coverage on exported APIs (`typedoc/require-exported-doc-comment`) plus tag correctness (unknown/duplicate/empty tags, malformed inline links). Scoped to `**/*.{ts,tsx,mts,cts}`.
 
 ```js
 import { createESLintConfig } from "@the-rabbit-hole/eslint-config";
 
-// A library that wants its public API documentation linted:
-export default createESLintConfig({ enable: ["eslintTypedoc"] });
+// A React component library that wants a11y, Storybook, and doc-coverage:
+export default createESLintConfig({
+  enable: ["eslintA11y", "eslintStorybook", "eslintTypedoc"],
+});
 ```
+
+> **Upgrading from 0.4.x:** `eslintA11y`, `eslintTesting`, and `eslintStorybook` used to be on by default. They are now opt-in — add them to `enable` (and remove them from `disableExtends`) if your project relied on them.
 
 ## 🧩 What’s Included?
 
 This ESLint config comes pre-bundled with a set of plugins and shareable configs tailored for modern TypeScript + React projects:
 
-### Plugins
+### Default plugins (on by default)
 
 * [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) ⚛️ — React best practices
-* [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) ♿️ — Accessibility rules for JSX
-* [eslint-plugin-testing-library](https://github.com/testing-library/eslint-plugin-testing-library) 🧪 — Testing Library linting
-* [eslint-plugin-storybook](https://github.com/storybookjs/eslint-plugin-storybook) 📖 — Storybook linting
 * [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) 🎨 — Run Prettier as an ESLint rule
 * [eslint-plugin-perfectionist](https://perfectionist.dev) 🪄 — Enforces sorting and consistency
 * [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn) 🦄— Massive rules for good code
+* [typescript-eslint](https://typescript-eslint.io) 🟦 — TypeScript linting
 
-### Opt-in plugins
+### Opt-in plugins (`enable`)
 
-* [eslint-plugin-typedoc](https://github.com/Nick2bad4u/eslint-plugin-typedoc) 📚 — TypeDoc/TSDoc documentation quality (enable with `enable: ["eslintTypedoc"]`)
+* [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) ♿️ — Accessibility rules for JSX (`enable: ["eslintA11y"]`)
+* [eslint-plugin-testing-library](https://github.com/testing-library/eslint-plugin-testing-library) 🧪 — Testing Library linting (`enable: ["eslintTesting"]`)
+* [eslint-plugin-storybook](https://github.com/storybookjs/eslint-plugin-storybook) 📖 — Storybook linting (`enable: ["eslintStorybook"]`)
+* [eslint-plugin-typedoc](https://github.com/Nick2bad4u/eslint-plugin-typedoc) 📚 — TypeDoc/TSDoc documentation quality (`enable: ["eslintTypedoc"]`)
 
 ## 🎨 A note on Prettier
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -61,37 +61,46 @@ describe("createESLintConfig", () => {
   });
 
   describe("disableExtends", () => {
-    it("includes every bundled extend by default", () => {
+    it("includes the default-on base extends by default", () => {
       const config = createESLintConfig() as ConfigEntry[];
-      expect(includesPlugin(config, "jsx-a11y")).toBe(true);
-      expect(includesPlugin(config, "storybook")).toBe(true);
       expect(includesPlugin(config, "typescript-eslint")).toBe(true);
       expect(includesPlugin(config, "unicorn")).toBe(true);
     });
 
-    it("removes only the entries named in disableExtends", () => {
+    it("does not include the opt-in extends by default", () => {
+      const config = createESLintConfig() as ConfigEntry[];
+      expect(includesPlugin(config, "jsx-a11y")).toBe(false);
+      expect(includesPlugin(config, "storybook")).toBe(false);
+      expect(includesPlugin(config, "typedoc")).toBe(false);
+    });
+
+    it("removes only the base entry named in disableExtends", () => {
       const config = createESLintConfig({
-        disableExtends: ["eslintStorybook", "eslintA11y"],
+        disableExtends: ["eslintUnicorn"],
       }) as ConfigEntry[];
 
-      expect(includesPlugin(config, "storybook")).toBe(false);
-      expect(includesPlugin(config, "jsx-a11y")).toBe(false);
-      expect(includesPlugin(config, "unicorn")).toBe(true);
+      expect(includesPlugin(config, "unicorn")).toBe(false);
       expect(includesPlugin(config, "typescript-eslint")).toBe(true);
     });
   });
 
   describe("enable (opt-in extends)", () => {
-    it("does not include eslintTypedoc by default", () => {
+    it("does not include any opt-in extend by default", () => {
       const config = createESLintConfig() as ConfigEntry[];
+      expect(includesPlugin(config, "jsx-a11y")).toBe(false);
+      expect(includesPlugin(config, "storybook")).toBe(false);
+      expect(includesPlugin(config, "testing-library")).toBe(false);
       expect(includesPlugin(config, "typedoc")).toBe(false);
     });
 
-    it("adds eslintTypedoc only when named in enable", () => {
+    it("adds only the opt-in extends named in enable", () => {
       const config = createESLintConfig({
-        enable: ["eslintTypedoc"],
+        enable: ["eslintA11y", "eslintTypedoc"],
       }) as ConfigEntry[];
+      expect(includesPlugin(config, "jsx-a11y")).toBe(true);
       expect(includesPlugin(config, "typedoc")).toBe(true);
+      expect(includesPlugin(config, "storybook")).toBe(false);
+      expect(includesPlugin(config, "testing-library")).toBe(false);
     });
 
     it("leaves the base extends intact when an opt-in extend is enabled", () => {

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -64,7 +64,7 @@ const hasPluginRule = (messages: Message[], prefix: string): boolean =>
 // it explicitly so the failure is visible the day it gets fixed.
 const REACT_BREAKS_ON_V10 = true;
 
-describe("integration: real ESLint run against sample code (default config minus React)", () => {
+describe("integration: real ESLint run against sample code (base config minus React)", () => {
   let eslint: ESLint;
 
   beforeAll(() => {
@@ -82,19 +82,6 @@ describe("integration: real ESLint run against sample code (default config minus
         "sample.ts",
       );
       expect(messages).toBeDefined();
-    },
-    TEST_TIMEOUT,
-  );
-
-  it(
-    "fires eslint-plugin-jsx-a11y on an <img> with no alt",
-    async () => {
-      const messages = await lint(
-        eslint,
-        'export const Bad = () => <img src="x" />;\n',
-        "Component.tsx",
-      );
-      expect(hasPluginRule(messages, "jsx-a11y/")).toBe(true);
     },
     TEST_TIMEOUT,
   );
@@ -142,8 +129,47 @@ describe("integration: real ESLint run against sample code (default config minus
   );
 
   it(
-    "fires eslint-plugin-storybook on a *.stories.tsx file",
+    "does not fire jsx-a11y, storybook, or testing-library by default",
     async () => {
+      const messages = await lint(
+        eslint,
+        'export const Bad = () => <img src="x" />;\n',
+        "Component.tsx",
+      );
+      expect(hasPluginRule(messages, "jsx-a11y/")).toBe(false);
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+// jsx-a11y, storybook, and testing-library are opt-in: they fire only when
+// named in `enable`. React is disabled because it crashes on eslint v10 (see
+// REACT_BREAKS_ON_V10) and these samples are .tsx files React would load.
+describe("integration: opt-in extends fire only when enabled", () => {
+  it(
+    "fires eslint-plugin-jsx-a11y on an <img> with no alt when enabled",
+    async () => {
+      const eslint = newEslint({
+        disableExtends: ["eslintReact"],
+        enable: ["eslintA11y"],
+      });
+      const messages = await lint(
+        eslint,
+        'export const Bad = () => <img src="x" />;\n',
+        "Component.tsx",
+      );
+      expect(hasPluginRule(messages, "jsx-a11y/")).toBe(true);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "fires eslint-plugin-storybook on a *.stories.tsx file when enabled",
+    async () => {
+      const eslint = newEslint({
+        disableExtends: ["eslintReact"],
+        enable: ["eslintStorybook"],
+      });
       const code = [
         'export default { title: "Foo" };',
         // `storybook/no-redundant-story-name` fires when a named export
@@ -158,8 +184,12 @@ describe("integration: real ESLint run against sample code (default config minus
   );
 
   it(
-    "fires eslint-plugin-testing-library on a test file",
+    "fires eslint-plugin-testing-library on a test file when enabled",
     async () => {
+      const eslint = newEslint({
+        disableExtends: ["eslintReact"],
+        enable: ["eslintTesting"],
+      });
       const code = [
         'import { render, cleanup } from "@testing-library/react";',
         'test("x", () => { render(null); cleanup(); });',
@@ -205,17 +235,17 @@ describe("integration: eslintTypedoc opt-in extend", () => {
 
 describe("integration: option wiring with various plugins on / off", () => {
   it(
-    "disableExtends actually drops the plugin's rules at lint time",
+    "disableExtends actually drops a base plugin's rules at lint time",
     async () => {
       const eslint = newEslint({
-        disableExtends: ["eslintA11y", "eslintReact"],
+        disableExtends: ["eslintReact", "eslintUnicorn"],
       });
       const messages = await lint(
         eslint,
-        'export const Bad = () => <img src="x" />;\n',
-        "Component.tsx",
+        "export const arr = Array.from(new Set([1, 2, 3]));\n",
+        "sample.ts",
       );
-      expect(hasPluginRule(messages, "jsx-a11y/")).toBe(false);
+      expect(hasPluginRule(messages, "unicorn/")).toBe(false);
     },
     TEST_TIMEOUT,
   );
@@ -225,12 +255,9 @@ describe("integration: option wiring with various plugins on / off", () => {
     async () => {
       const eslint = newEslint({
         disableExtends: [
-          "eslintA11y",
           "eslintPerfectionist",
           "eslintPrettier",
           "eslintReact",
-          "eslintStorybook",
-          "eslintTesting",
         ],
       });
       const messages = await lint(

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,5 +23,8 @@ OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 import { createESLintConfig } from "./lib/esm/index.mjs";
 
 export default createESLintConfig({
-  disableExtends: ["eslintReact", "eslintA11y", "eslintStorybook"],
+  // eslintReact is on by default but breaks under ESLint v10 (see the
+  // integration suite); a11y/storybook/testing/typedoc are opt-in, so this
+  // config (a plain TS library) simply leaves them off.
+  disableExtends: ["eslintReact"],
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,12 +64,9 @@ export const globalIgnoresArray = [
 type ExtendFactory = () => Linter.Config | Linter.Config[];
 
 const baseExtendsMap = {
-  eslintA11y: (() => eslintA11y.recommended) as ExtendFactory,
   eslintPerfectionist: (() => eslintPerfectionist) as ExtendFactory,
   eslintPrettier: (() => eslintPrettier) as ExtendFactory,
   eslintReact: (() => eslintReact) as ExtendFactory,
-  eslintStorybook: (() => eslintStorybook()) as ExtendFactory,
-  eslintTesting: (() => eslintTesting) as ExtendFactory,
   eslintTypescript: (() => eslintTypescript.recommended) as ExtendFactory,
   eslintUnicorn: (() => eslintUnicorn) as ExtendFactory,
 };
@@ -77,12 +74,23 @@ const baseExtendsMap = {
 /**
  * Opt-in extends with string keys.
  * @remarks Unlike {@link baseExtendsMap}, these are never applied unless named
- * in `createESLintConfig({ enable })`. `eslintTypedoc` enforces TSDoc/TypeDoc
- * doc-comment coverage on exported APIs, so it is opt-in to keep non-library
- * consumers from being forced into doc-coverage errors.
+ * in `createESLintConfig({ enable })`. They target a specific kind of project
+ * rather than every consumer:
+ *
+ * - `eslintA11y` -- JSX accessibility rules (React component code).
+ * - `eslintStorybook` -- Storybook story linting.
+ * - `eslintTesting` -- Testing Library rules (test files).
+ * - `eslintTypedoc` -- TSDoc/TypeDoc doc-comment coverage on exported APIs.
+ *
+ * Keeping them opt-in means a plain Node library does not inherit
+ * accessibility, Storybook, Testing Library, or doc-coverage errors it has no
+ * use for.
  * @since 0.5.0
  */
 const optInExtendsMap = {
+  eslintA11y: (() => eslintA11y.recommended) as ExtendFactory,
+  eslintStorybook: (() => eslintStorybook()) as ExtendFactory,
+  eslintTesting: (() => eslintTesting) as ExtendFactory,
   eslintTypedoc: (() => eslintTypedoc) as ExtendFactory,
 };
 
@@ -99,7 +107,8 @@ const baseRules: Linter.RulesRecord = {
  * @since 1.0.0
  * @param options.disableExtends - Extend names (keys) to remove from base config
  * @param options.enable - Opt-in extend names (keys) to add on top of the base
- *   config. Currently `eslintTypedoc` (TSDoc/TypeDoc doc-coverage enforcement).
+ *   config: `eslintA11y`, `eslintStorybook`, `eslintTesting`, and
+ *   `eslintTypedoc`. All are off unless named here.
  * @param options.rules - Rules to merge on top of the base rules. Keys that
  *   collide with a base rule will replace it; an info message is printed for
  *   each override so the consumer is aware.


### PR DESCRIPTION
## What and why

Moves `eslintA11y`, `eslintTesting`, and `eslintStorybook` out of the default-on base extends and into the **opt-in** set, alongside `eslintTypedoc`. These three only apply to React component code, test files, or Storybook stories — forcing them on every consumer means a plain Node library inherits accessibility, Testing Library, and Storybook rules it has no use for.

After this change the opt-in set is `eslintA11y`, `eslintStorybook`, `eslintTesting`, `eslintTypedoc`; the default-on set is `eslintPerfectionist`, `eslintPrettier`, `eslintReact`, `eslintTypescript`, `eslintUnicorn`.

### Behavior change (breaking for consumers relying on the old defaults)

`createESLintConfig()` no longer includes these three by default, and their keys move from `disableExtends` to `enable`:

```js
createESLintConfig({ enable: ["eslintA11y", "eslintTesting", "eslintStorybook"] });
```

Semver-wise this is acceptable for a 0.x minor; the README documents the upgrade path. (Publish as 1.0.0 instead if you want to signal the break more strongly.)

Closes #49

## Verification

- [x] Lint clean (`npm run lint`)
- [x] Tests pass (`npm test` — 26 passed, 1 skipped: the documented react/v10 case)
- [x] Build succeeds (`npm run build`)
- [x] Documentation updated (README, AGENTS.md)

## How this was verified

`npm run build`, `npm test`, `npm run lint`, and `npm run docs` all green on the final tree. Unit tests assert the three extends are absent by default and added only when named in `enable`; integration tests run real ESLint and confirm `jsx-a11y/`, `storybook/`, and `testing-library/` rules fire only when enabled (with `eslintReact` disabled, since it crashes on ESLint v10). This repo's own `eslint.config.mjs` was updated since it previously disabled `eslintA11y`/`eslintStorybook`, which are no longer valid `disableExtends` keys.