### PR TITLE
ci: add an eslint 9/10 compatibility matrix to the test workflow

### DIFF
--- a/.github/workflows/action-test.yaml
+++ b/.github/workflows/action-test.yaml
@@ -80,3 +80,37 @@ jobs:
             LICENSE
             CHANGELOG.md
             ./lib
+
+  # Run the suite against each eslint major the package advertises in its peer
+  # range. The integration tests load the config through createESLintConfig and
+  # run real ESLint, so a bundled plugin that drops support for one major fails
+  # at config-load time here instead of shipping (regression guard for #51).
+  ESLintCompat:
+    name: 🧩 ESLint ${{ matrix.eslint }}.x
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        eslint: ['9', '10']
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate lockfile
+        run: npm install --package-lock-only --ignore-scripts --legacy-peer-deps
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --legacy-peer-deps
+
+      - name: Pin eslint ${{ matrix.eslint }}.x
+        run: npm install --no-save --ignore-scripts --legacy-peer-deps "eslint@${{ matrix.eslint }}"
+
+      - name: Show resolved eslint version
+        run: npx eslint --version
+
+      - name: Run tests against eslint ${{ matrix.eslint }}.x
+        run: npm test


### PR DESCRIPTION
## What and why

The test workflow only ran against the single `eslint` version pinned in devDependencies (10.x), so nothing exercised the config on **eslint 9**. That is exactly how the v0.5.0 regression (#51) shipped: `eslint-plugin-unicorn@69` dropped eslint 9 (peer `>=10.4`) while the package still advertised `eslint ^9.39.4 || ^10.0.0`, and CI never noticed.

Adds an `ESLintCompat` job that runs the test suite against **each eslint major in the advertised peer range (9 and 10)**. Because the integration tests load the config through `createESLintConfig` and run real ESLint, a bundled plugin that no longer supports a given major fails at config-load time in CI instead of reaching consumers.

Closes #54

## Verification

- [x] Workflow runs the suite against eslint 9.x and 10.x
- [x] Both legs pass on the current (fixed) dependency set

## How this was verified

Ran the matrix locally: pinned `eslint@9` over the tree (`npm install --no-save eslint@9`) and `npm test` → 26 passed / 1 skipped; restored `eslint@10.6` → still green. The job is the CI equivalent. Reintroducing unicorn 66+ (which I confirmed crashes the config at load on eslint 9) would fail the eslint 9 leg.

Recommended to land **before** publishing v0.5.1 so the guard is validating that release.