### PR TITLE
ci: drop the release auto-publish step and authenticate setup-task

### DIFF
--- a/.github/workflows/job-golic.yaml
+++ b/.github/workflows/job-golic.yaml
@@ -29,8 +29,9 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Authenticate setup-task's GitHub API calls; without this it uses
+          # the anonymous rate limit and fails with "API rate limit exceeded".
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify MIT headers
         run: |
           export PATH="${PATH}:$(go env GOPATH)/bin"

--- a/.github/workflows/job-version-bump.yaml
+++ b/.github/workflows/job-version-bump.yaml
@@ -58,8 +58,9 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Authenticate setup-task's GitHub API calls; without this it uses
+          # the anonymous rate limit and fails with "API rate limit exceeded".
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📝 Release Drafter (Anticipate Version)
         id: drafter
@@ -108,12 +109,3 @@ jobs:
           commit_user_name: ${{ github.actor }}
           commit_user_email: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
           commit_author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-
-      - name: 🏷️ Publish Release
-        if: contains(github.event.head_commit.author.name, 'dependabot') || contains(github.event.head_commit.message, 'dependabot')
-        uses: release-drafter/release-drafter@v7
-        with:
-          publish: true
-          commitish: main
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What and why

Two CI workflow reliability fixes, folded into the v0.5.1 release.

### Remove the release auto-publish step (closes #53)

The Release Manager (`job-version-bump.yaml`) had a `🏷️ Publish Release` step gated on `contains(head_commit.author.name, "dependabot") || contains(head_commit.message, "dependabot")`. The message clause matched any merge merely mentioning "dependabot", so the squash-merge of the Dependabot removal (#43, PR #47) auto-published a release and shipped it to npm — bypassing the documented "the maintainer publishes the GitHub Release manually" flow. The step is removed; nothing auto-publishes.

Note: only the publish step is removed. The bump stays on `task update-version`, which also syncs the Taskfile `VERSION` var (a bare `npm version` would not), so this repo keeps its working mechanism rather than reverting wholesale to the hub template — the hub should adopt the task-based bump instead.

### Authenticate `arduino/setup-task` (fixes the GoLic rate-limit failure)

`setup-task` was failing with `API rate limit exceeded` because it used the anonymous GitHub API limit. The step had an `env: GITHUB_TOKEN`, but the action reads the **`repo-token` input**, not env. Pass `repo-token: ${{ secrets.GITHUB_TOKEN }}` in both the GoLic and version-bump workflows.

Closes #53

## Verification

- [x] Both workflow files parse as valid YAML
- [x] `app-token` is still referenced by the Checkout step (no dangling reference after removing the publish step)
- [x] actionlint / CI green (see checks)

## How this was verified

Parsed both YAML files locally; confirmed the only remaining `app-token` use is the Checkout token (the removed publish step was the other consumer). The Release Manager now ends at the version-bump commit step with no auto-publish. The `repo-token` input is the documented auth for `arduino/setup-task@v2`.