### PR TITLE
feat: enforce arrow-function style via func-style

### DIFF
--- a/src/eslintStorybook.ts
+++ b/src/eslintStorybook.ts
@@ -36,11 +36,13 @@ const requirePlugin = createRequire(import.meta.url);
  * skipped instead, so Node libraries never need to install it.
  * @since 1.0.0
  */
-export default function eslintStorybook(): Linter.Config[] {
+const eslintStorybook = (): Linter.Config[] => {
   try {
     const storybook = requirePlugin("eslint-plugin-storybook");
     return storybook.configs["flat/recommended"];
   } catch {
     return [];
   }
-}
+};
+
+export default eslintStorybook;

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,10 @@ const optInExtendsMap = {
  * @since 1.0.0
  */
 const baseRules: Linter.RulesRecord = {
+  // Enforce arrow-function style: functions must be expressions (arrow
+  // functions), not declarations. A consumer that must use a declaration can
+  // override this key via createESLintConfig({ rules }).
+  "func-style": ["error", "expression"],
   "react/react-in-jsx-scope": "off",
 };
 
@@ -132,11 +136,11 @@ const baseRules: Linter.RulesRecord = {
  *   collide with a base rule will replace it; an info message is printed for
  *   each override so the consumer is aware.
  */
-export function createESLintConfig(options?: {
+export const createESLintConfig = (options?: {
   disableExtends?: (keyof typeof baseExtendsMap)[];
   enable?: (keyof typeof optInExtendsMap)[];
   rules?: Linter.RulesRecord;
-}) {
+}) => {
   const disabled = options?.disableExtends ?? [];
   const enabled = options?.enable ?? [];
   const userRules = options?.rules ?? {};
@@ -177,7 +181,7 @@ export function createESLintConfig(options?: {
       },
     },
   ]);
-}
+};
 
 /**
  * Default Config


### PR DESCRIPTION
## What and why

The shared config did not enforce a function-definition style, so consuming repos mixed `function` declarations and arrow-function expressions. This adds `func-style: ["error", "expression"]` to the bundled `baseRules` so functions must be arrow-function expressions. A consumer that needs a declaration can override the key via `createESLintConfig({ rules })`, which already prints an info message on override.

The config dogfoods its own rules, so `createESLintConfig` and `eslintStorybook` are converted from `function` declarations to arrow functions in the same change.

Closes #60

## Verification

- [x] Lint clean
- [x] Tests pass
- [x] Build succeeds

## How this was verified

- `npm run build` — clean
- `npm run lint` — clean (dogfoods the new rule)
- `npm test` — 28 passed, 1 skipped
- `task license` — 0/13 changed